### PR TITLE
Prevent page refresh during conversion flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,11 +12,20 @@
       <p class="description">
         YouTube のチャンネル URL や @ハンドルを貼り付けると RSS フィード URL を生成します。
       </p>
-      <form id="converter-form" class="card">
-        <label for="channel-input" class="field-label">チャンネル URL または @ハンドル</label>
-        <input id="channel-input" type="text" name="channel" placeholder="https://www.youtube.com/@example" required />
-        <button type="submit">変換する</button>
-      </form>
+      <section id="converter-form" class="card" role="form" aria-labelledby="channel-input-label">
+        <label id="channel-input-label" for="channel-input" class="field-label"
+          >チャンネル URL または @ハンドル</label
+        >
+        <input
+          id="channel-input"
+          type="text"
+          name="channel"
+          placeholder="https://www.youtube.com/@example"
+          autocomplete="off"
+          required
+        />
+        <button type="button" id="convert-button">変換する</button>
+      </section>
       <p id="error-message" class="error" hidden></p>
       <div id="output" class="card" hidden>
         <label for="rss-result" class="field-label">RSS フィード URL</label>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,14 +2,14 @@ import {
   buildFeedUrl,
   parseChannelIdentifier,
   ChannelIdentifierResult,
-} from './conversion';
+} from './conversion.js';
 
-const form = document.querySelector<HTMLFormElement>('#converter-form');
 const inputField = document.querySelector<HTMLInputElement>('#channel-input');
 const outputContainer = document.querySelector<HTMLDivElement>('#output');
 const resultField = document.querySelector<HTMLInputElement>('#rss-result');
 const errorField = document.querySelector<HTMLParagraphElement>('#error-message');
 const copyButton = document.querySelector<HTMLButtonElement>('#copy-button');
+const convertButton = document.querySelector<HTMLButtonElement>('#convert-button');
 
 function resetMessages() {
   if (errorField) {
@@ -64,12 +64,28 @@ async function resolveChannelId(result: ChannelIdentifierResult): Promise<void> 
   showError(result.message);
 }
 
-if (form && inputField) {
-  form.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    resetMessages();
-    const result = parseChannelIdentifier(inputField.value);
-    await resolveChannelId(result);
+async function handleConversion(): Promise<void> {
+  if (!inputField) {
+    return;
+  }
+
+  resetMessages();
+  const result = parseChannelIdentifier(inputField.value);
+  await resolveChannelId(result);
+}
+
+if (convertButton) {
+  convertButton.addEventListener('click', async () => {
+    await handleConversion();
+  });
+}
+
+if (inputField) {
+  inputField.addEventListener('keydown', async (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      await handleConversion();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- replace the converter form with an accessible section and button so submitting no longer reloads the page
- update the frontend script to reuse a shared conversion handler for both button clicks and Enter key presses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db372f651c8332abdcc4a561444a6c