### PR TITLE
Fix API import path for conversion module

### DIFF
--- a/api/resolve.ts
+++ b/api/resolve.ts
@@ -3,7 +3,7 @@ import {
   extractChannelIdFromHtml,
   parseChannelIdentifier,
   isChannelId,
-} from '../src/conversion';
+} from '../src/conversion.js';
 
 const USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36';

--- a/tests/conversion.test.ts
+++ b/tests/conversion.test.ts
@@ -4,7 +4,7 @@ import {
   extractChannelIdFromHtml,
   parseChannelIdentifier,
   isChannelId,
-} from '../src/conversion';
+} from '../src/conversion.js';
 
 describe('parseChannelIdentifier', () => {
   it('parses direct channel id', () => {


### PR DESCRIPTION
## Summary
- update the serverless resolve handler to import the shared conversion utilities using the `.js` specifier required by the Node.js ESM runtime
- align the Vitest suite with the same module specifier so local tests continue to execute

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db587e1dbc83329a45c52b6d65c308