### PR TITLE
Add success notification and refresh RSS conversion results

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,13 @@
         <button type="button" id="convert-button" data-i18n="convert">Convert</button>
       </section>
       <p id="error-message" class="error" hidden></p>
+      <p
+        id="success-message"
+        class="success"
+        role="status"
+        aria-live="polite"
+        hidden
+      ></p>
       <div id="output" class="card" hidden>
         <label for="rss-result" class="field-label" data-i18n="resultLabel">RSS feed URL</label>
         <div class="result-row">

--- a/public/styles.css
+++ b/public/styles.css
@@ -99,6 +99,11 @@ button:hover {
   margin: 0;
 }
 
+.success {
+  color: #047857;
+  margin: 0;
+}
+
 .result-row {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add a localized success notification that appears on successful conversions and auto-hides after a short delay
- guard asynchronous lookups so the RSS URL field always reflects the most recent conversion
- update styles and markup to support the new notification message

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd2cc559548332b879579af411ccae